### PR TITLE
Pair of patterns with value pattern must also have value pattern

### DIFF
--- a/src/Control/Egison/Matcher/Pair.hs
+++ b/src/Control/Egison/Matcher/Pair.hs
@@ -26,3 +26,13 @@ tuple2 _ (Pair m1 m2) (t1, t2) = pure (t1, t2)
 
 tuple2M :: Pair m1 m2 -> (t1, t2) -> (m1, m2)
 tuple2M (Pair m1 m2) _ = (m1, m2)
+
+instance (Eq a1, Matcher m1 a1, ValuePattern m1 a1, Eq a2, Matcher m2 a2, ValuePattern m2 a2) => ValuePattern (Pair m1 m2) (a1, a2) where
+  value (e1, e2) () (Pair m1 m2) (v1, v2) = if eqAs m1 e1 v1 && eqAs m2 e2 v2 then pure () else mzero
+
+eqAs :: (Matcher m t, ValuePattern m t) => m -> t -> t -> Bool
+eqAs m x y =
+  match dfs y m
+    [ [mc| #x -> True |]
+    , [mc| _ -> False |]
+    ]


### PR DESCRIPTION
Working example:
```hs
vpTest x =
  match dfs x (Pair Eql (Multiset Eql))
    [ [mc| #(3, [1, 2, 3]) -> True |]
    , [mc| _ -> False |]]

main = do
  print $ vpTest (3, [3, 2, 1]) -- True
```